### PR TITLE
[mellanox] Change the default timeout of get_transceiver_change_event()

### DIFF
--- a/device/mellanox/x86_64-mlnx_msn2700-r0/plugins/sfputil.py
+++ b/device/mellanox/x86_64-mlnx_msn2700-r0/plugins/sfputil.py
@@ -176,7 +176,11 @@ class SfpUtil(SfpUtilBase):
         if 'LIVENESS' not in keys:
             return False, phy_port_dict
 
-        (state, c) = self.db_sel.select(timeout)
+        if timeout:
+            (state, c) = self.db_sel.select(timeout)
+        else:
+            (state, c) = self.db_sel.select()
+
         if state == self.db_sel_timeout:
             status = True
         elif state != self.db_sel_object:


### PR DESCRIPTION
Signed-off-by: Kevin Wang <kevinw@mellanox.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
Xcvrd daemon will always use more than 50% CPU utilization in Mellanox platform. The root cause is Xcvrd will loop to get the change_event information using function get_transceiver_change_event(timeout) which is implemented in sfputil.py per platform. On Mellanox platform, get_transceiver_change_event() will return immediately by default even there is no SFP change event happened. So the Xcvrd deamon will always busy.

**- How I did it**
Change the default timeout value to SELECT_NO_TIMEOUT which means the select will block until some events happened. 

**- How to verify it**
The CPU utilization of xcvrd thread will become nearly 0% after this change.

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**
